### PR TITLE
docs: Change README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Duke project template
+# MediTracker 
 
-This is a project template for a greenfield Java project. It's named after the Java mascot _Duke_. Given below are instructions on how to use it.
+This is a project based off of a template for a greenfield Java project. Given below are instructions on how to use it.
 
 ## Setting up in Intellij
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
-# Duke
+# MediTracker 
 
-{Give product intro here}
+A place to track all your medications!
 
 Useful links:
 * [User Guide](UserGuide.md)


### PR DESCRIPTION
Changes the default README title to the one used by our project, MediTracker