### PR TITLE
Misc: change package name and update PR Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,6 @@
 # Checklist for feature implementation and modification
-- [ ] Issue addressed: Issue #x
+- [ ] Issue addressed: Closes #<Issue_Number>
 - [ ] Added relevant milestone (under milestone tab on the right)
-- [ ] Added relevant issue (under development tab on the right)
 - Implementation
   - [ ] Sources (if any) credited under both relevant section(s) and Developer Guide (Acknowledgement)
   - [ ] JUnit Test(s)
@@ -24,9 +23,8 @@
 
 
 # Checklist for non-implementation related PR
-- [ ] Issue addressed: Issue #x
+- [ ] Issue addressed: Closes #<Issue_Number>
 - [ ] Added relevant milestone (under milestone tab on the right)
-- [ ] Added relevant issue (under development tab on the right)
 - Documentation (Contributions)
   - [ ] Developer Guide contributions (if any)
   - [ ] User Guide contributions (if any)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,7 @@
 # Checklist for feature implementation and modification
 - [ ] Issue addressed: Issue #x
+- [ ] Added relevant milestone (under milestone tab on the right)
+- [ ] Added relevant issue (under development tab on the right)
 - Implementation
   - [ ] Sources (if any) credited under both relevant section(s) and Developer Guide (Acknowledgement)
   - [ ] JUnit Test(s)
@@ -23,6 +25,8 @@
 
 # Checklist for non-implementation related PR
 - [ ] Issue addressed: Issue #x
+- [ ] Added relevant milestone (under milestone tab on the right)
+- [ ] Added relevant issue (under development tab on the right)
 - Documentation (Contributions)
   - [ ] Developer Guide contributions (if any)
   - [ ] User Guide contributions (if any)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 # Checklist for feature implementation and modification
-- [ ] Issue addressed: Closes #<Issue_Number>
+Closes #<Issue_Number>
 - [ ] Added relevant milestone (under milestone tab on the right)
 - Implementation
   - [ ] Sources (if any) credited under both relevant section(s) and Developer Guide (Acknowledgement)
@@ -23,7 +23,7 @@
 
 
 # Checklist for non-implementation related PR
-- [ ] Issue addressed: Closes #<Issue_Number>
+Closes #<Issue_Number>
 - [ ] Added relevant milestone (under milestone tab on the right)
 - Documentation (Contributions)
   - [ ] Developer Guide contributions (if any)

--- a/build.gradle
+++ b/build.gradle
@@ -29,11 +29,11 @@ test {
 }
 
 application {
-    mainClass.set("seedu.meditracker.MediTracker")
+    mainClass.set("meditracker.MediTracker")
 }
 
 shadowJar {
-    archiveBaseName.set("duke")
+    archiveBaseName.set("meditracker")
     archiveClassifier.set("")
 }
 

--- a/src/main/java/meditracker/MediTracker.java
+++ b/src/main/java/meditracker/MediTracker.java
@@ -1,6 +1,6 @@
-package seedu.meditracker;
+package meditracker;
 
-import seedu.meditracker.ui.Ui;
+import meditracker.ui.Ui;
 
 /**
  * The main class for the MediTracker application.

--- a/src/main/java/meditracker/ui/Ui.java
+++ b/src/main/java/meditracker/ui/Ui.java
@@ -1,4 +1,4 @@
-package seedu.meditracker.ui;
+package meditracker.ui;
 
 import java.util.Scanner;
 

--- a/src/test/java/meditracker/MediTrackerTest.java
+++ b/src/test/java/meditracker/MediTrackerTest.java
@@ -1,10 +1,10 @@
-package seedu.meditracker;
+package meditracker;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
-class SearchMedicationTest {
+class MediTrackerTest {
     @Test
     public void sampleTest() {
         assertTrue(true);

--- a/src/test/java/meditracker/SearchMedicationTest.java
+++ b/src/test/java/meditracker/SearchMedicationTest.java
@@ -1,10 +1,10 @@
-package seedu.meditracker;
+package meditracker;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
-class MediTrackerTest {
+class SearchMedicationTest {
     @Test
     public void sampleTest() {
         assertTrue(true);


### PR DESCRIPTION
# Checklist for non-implementation related PR
Closes #21 

# Additional Information
With the inclusion of the closing keyword `closes`, the relevant issue should be automatically linked under the development tab on the right upon the creation of the PR.

Package name has been updated to remove the unnecessary `seedu` prefix
