### PR TITLE
test: Add modify tests

### DIFF
--- a/src/main/java/meditracker/command/AddCommand.java
+++ b/src/main/java/meditracker/command/AddCommand.java
@@ -61,6 +61,9 @@ public class AddCommand extends Command {
      */
     public AddCommand(String arguments) throws HelpInvokedException, ArgumentException {
         parsedArguments = ARGUMENT_LIST.parse(arguments);
+        if (!parsedArguments.containsKey(ArgumentName.REMARKS)) {
+            parsedArguments.put(ArgumentName.REMARKS, null);
+        }
     }
 
     /**

--- a/src/main/java/meditracker/command/ModifyCommand.java
+++ b/src/main/java/meditracker/command/ModifyCommand.java
@@ -122,11 +122,11 @@ public class ModifyCommand extends Command {
         for (Map.Entry<ArgumentName, String> argument: parsedArguments.entrySet()) {
             ArgumentName argumentName = argument.getKey();
             String argumentValue = argument.getValue();
-            medication.setMedicationValue(argumentName, argumentValue);
 
             if (argumentName == ArgumentName.NAME) {
                 DailyMedicationManager.updateDailyMedicationName(medication, argumentValue);
             }
+            medication.setMedicationValue(argumentName, argumentValue);
         }
         medication.checkValidity();
         checkDosageOrRepeatModified(medication);

--- a/src/main/java/meditracker/command/ModifyCommand.java
+++ b/src/main/java/meditracker/command/ModifyCommand.java
@@ -21,6 +21,8 @@ import meditracker.medication.MedicationManager;
 import meditracker.storage.FileReaderWriter;
 import meditracker.ui.Ui;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -41,6 +43,7 @@ public class ModifyCommand extends Command {
     );
     public static final String HELP_MESSAGE = ArgumentHelper.getHelpMessage(CommandName.MODIFY, ARGUMENT_LIST);
     private final Map<ArgumentName, String> parsedArguments;
+    private final List<ArgumentName> processedArguments;
 
     /**
      * Constructs a ModifyCommand object with the specified arguments.
@@ -54,6 +57,7 @@ public class ModifyCommand extends Command {
      */
     public ModifyCommand(String arguments) throws HelpInvokedException, ArgumentException {
         parsedArguments = ARGUMENT_LIST.parse(arguments);
+        processedArguments = new ArrayList<>();
     }
 
     /**
@@ -106,7 +110,7 @@ public class ModifyCommand extends Command {
      * @throws MediTrackerException Unable to revert Medication
      */
     private void rollbackChanges(Medication medication, Medication medicationCopy) throws MediTrackerException {
-        if (parsedArguments.containsKey(ArgumentName.NAME)) {
+        if (processedArguments.contains(ArgumentName.NAME)) {
             String oldName = medicationCopy.getName();
             DailyMedicationManager.updateDailyMedicationName(medication, oldName);
         }
@@ -127,6 +131,7 @@ public class ModifyCommand extends Command {
                 DailyMedicationManager.updateDailyMedicationName(medication, argumentValue);
             }
             medication.setMedicationValue(argumentName, argumentValue);
+            processedArguments.add(argumentName);
         }
         medication.checkValidity();
         checkDosageOrRepeatModified(medication);

--- a/src/test/java/meditracker/command/ModifyCommandTest.java
+++ b/src/test/java/meditracker/command/ModifyCommandTest.java
@@ -23,16 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ModifyCommandTest {
 
-    @BeforeEach
-    @AfterEach
-    void resetManagers() throws InvocationTargetException, IllegalAccessException, NoSuchMethodException {
-        DailyMedicationManagerTest.resetDailyMedicationManager();
-        MedicationManagerTest.resetMedicationManager();
-    }
-
-    @Test
-    void execute_inOrderArgument_expectMedicationModified()
-            throws HelpInvokedException, MediTrackerException, ArgumentException {
+    void setupMedication() throws MediTrackerException {
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
         LocalDate parsedExpiryDate = LocalDate.parse("2025-07-01", dateTimeFormatter);
         Medication medication = new Medication(
@@ -47,6 +38,28 @@ public class ModifyCommandTest {
                 87);
         MedicationManager.addMedication(medication);
         DailyMedicationManager.checkForDaily(medication);
+    }
+
+    private static String getExpectedOutput(ByteArrayOutputStream output, String errorMessage) {
+        Ui.showErrorMessage(errorMessage);
+        Ui.showWarningMessage("Rolling back changes...");
+        Ui.showInfoMessage("Changes have been rolled back. Medicine not modified.");
+        String expectedOutput = output.toString();
+        output.reset();
+        return expectedOutput;
+    }
+
+    @BeforeEach
+    @AfterEach
+    void resetManagers() throws InvocationTargetException, IllegalAccessException, NoSuchMethodException {
+        DailyMedicationManagerTest.resetDailyMedicationManager();
+        MedicationManagerTest.resetMedicationManager();
+    }
+
+    @Test
+    void execute_inOrderArgument_expectMedicationModified()
+            throws HelpInvokedException, MediTrackerException, ArgumentException {
+        setupMedication();
 
         String newName = "Medication B";
         String inputString = "-l 1 -n " + newName;
@@ -60,20 +73,7 @@ public class ModifyCommandTest {
     @Test
     void execute_outOfOrderArgument_expectMedicationModified()
             throws HelpInvokedException, MediTrackerException, ArgumentException {
-        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-        LocalDate parsedExpiryDate = LocalDate.parse("2025-07-01", dateTimeFormatter);
-        Medication medication = new Medication(
-                "Medication A",
-                60.0,
-                10.0,
-                10.0,
-                10.0,
-                parsedExpiryDate,
-                "cause_dizziness",
-                1,
-                87);
-        MedicationManager.addMedication(medication);
-        DailyMedicationManager.checkForDaily(medication);
+        setupMedication();
 
         String newName = "Medication B";
         String inputString = String.format("-n %s -l 1", newName);
@@ -108,6 +108,179 @@ public class ModifyCommandTest {
         new ModifyCommand("-l 4 [-h]").execute();
         actualOutput = output.toString();
         output.reset();
+        assertEquals(expectedOutput, actualOutput);
+
+        System.setOut(originalOut); // restore stream
+    }
+
+    @Test
+    void execute_onlyListIndex_noChangesSpecified()
+            throws HelpInvokedException, ArgumentException, MediTrackerException {
+        //Solution below adapted by https://stackoverflow.com/questions/58665761
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        PrintStream originalOut = System.out;
+        System.setOut(new PrintStream(output)); // set up capture stream
+
+        Ui.showSuccessMessage("No changes specified. Medicine not modified.");
+        String expectedOutput = output.toString();
+        output.reset();
+        setupMedication();
+
+        new ModifyCommand("-l 1").execute();
+        String actualOutput = output.toString();
+        output.reset();
+        assertEquals(expectedOutput, actualOutput);
+
+        System.setOut(originalOut); // restore stream
+    }
+
+    @Test
+    void execute_invalidName_rollbackChanges()
+            throws HelpInvokedException, ArgumentException, MediTrackerException {
+        //Solution below adapted by https://stackoverflow.com/questions/58665761
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        PrintStream originalOut = System.out;
+        System.setOut(new PrintStream(output)); // set up capture stream
+
+        setupMedication();
+
+        new ModifyCommand("-l 1 -q 70 -n Medication_B").execute();
+        String actualOutput = output.toString();
+        output.reset();
+        String expectedOutput = getExpectedOutput(output, "Please enter a proper medication name.");
+        assertEquals(expectedOutput, actualOutput);
+
+        System.setOut(originalOut); // restore stream
+    }
+
+    @Test
+    void execute_invalidQuantity_rollbackChanges()
+            throws HelpInvokedException, ArgumentException, MediTrackerException {
+        //Solution below adapted by https://stackoverflow.com/questions/58665761
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        PrintStream originalOut = System.out;
+        System.setOut(new PrintStream(output)); // set up capture stream
+
+        setupMedication();
+
+        new ModifyCommand("-l 1 -q seventy -n Medication B").execute();
+        String actualOutput = output.toString();
+        output.reset();
+        String expectedOutput = getExpectedOutput(output, "Unable to parse String 'seventy' into double.");
+        assertEquals(expectedOutput, actualOutput);
+
+        System.setOut(originalOut); // restore stream
+    }
+
+    @Test
+    void execute_invalidDosage_rollbackChanges()
+            throws HelpInvokedException, ArgumentException, MediTrackerException {
+        //Solution below adapted by https://stackoverflow.com/questions/58665761
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        PrintStream originalOut = System.out;
+        System.setOut(new PrintStream(output)); // set up capture stream
+
+        setupMedication();
+
+        new ModifyCommand("-l 1 -q 70 -dM ten").execute();
+        String actualOutput = output.toString();
+        output.reset();
+        String expectedOutput = getExpectedOutput(output, "Unable to parse String 'ten' into double.");
+        assertEquals(expectedOutput, actualOutput);
+
+        new ModifyCommand("-l 1 -q 70 -dM ten").execute();
+        actualOutput = output.toString();
+        output.reset();
+        expectedOutput = getExpectedOutput(output, "Unable to parse String 'ten' into double.");
+        assertEquals(expectedOutput, actualOutput);
+
+        new ModifyCommand("-l 1 -q 70 -dA ten").execute();
+        actualOutput = output.toString();
+        output.reset();
+        expectedOutput = getExpectedOutput(output, "Unable to parse String 'ten' into double.");
+        assertEquals(expectedOutput, actualOutput);
+
+        new ModifyCommand("-l 1 -q 70 -dE ten").execute();
+        actualOutput = output.toString();
+        output.reset();
+        expectedOutput = getExpectedOutput(output, "Unable to parse String 'ten' into double.");
+        assertEquals(expectedOutput, actualOutput);
+
+        new ModifyCommand("-l 1 -q 70 -dM 0 -dA 0 -dE 0").execute();
+        actualOutput = output.toString();
+        output.reset();
+        expectedOutput = getExpectedOutput(
+                output,
+                "Medication has no dosages. " +
+                        "Please ensure at least 1 period of day has dosage (-dM, -dA and/or -dE).");
+        assertEquals(expectedOutput, actualOutput);
+
+        System.setOut(originalOut); // restore stream
+    }
+
+    @Test
+    void execute_invalidExpirationDate_rollbackChanges()
+            throws HelpInvokedException, ArgumentException, MediTrackerException {
+        //Solution below adapted by https://stackoverflow.com/questions/58665761
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        PrintStream originalOut = System.out;
+        System.setOut(new PrintStream(output)); // set up capture stream
+
+        setupMedication();
+
+        new ModifyCommand("-l 1 -e 3000-13-32").execute();
+        String actualOutput = output.toString();
+        output.reset();
+        String expectedOutput = getExpectedOutput(output, "Please enter a valid expiry date in yyyy-MM-dd!");
+        assertEquals(expectedOutput, actualOutput);
+
+        new ModifyCommand("-l 1 -e 1900-12-31").execute();
+        actualOutput = output.toString();
+        output.reset();
+        expectedOutput = getExpectedOutput(output, "You are not allowed to enter expired medications!");
+        assertEquals(expectedOutput, actualOutput);
+
+        System.setOut(originalOut); // restore stream
+    }
+
+    @Test
+    void execute_invalidRepeat_rollbackChanges()
+            throws HelpInvokedException, ArgumentException, MediTrackerException {
+        //Solution below adapted by https://stackoverflow.com/questions/58665761
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        PrintStream originalOut = System.out;
+        System.setOut(new PrintStream(output)); // set up capture stream
+
+        setupMedication();
+
+        new ModifyCommand("-l 1 -rep 1.0E1000").execute();
+        String actualOutput = output.toString();
+        output.reset();
+        String expectedOutput = getExpectedOutput(output, "Unable to parse String '1.0E1000' into integer.");
+        assertEquals(expectedOutput, actualOutput);
+
+        new ModifyCommand("-l 1 -rep NaN").execute();
+        actualOutput = output.toString();
+        output.reset();
+        expectedOutput = getExpectedOutput(output, "Unable to parse String 'NaN' into integer.");
+        assertEquals(expectedOutput, actualOutput);
+
+        new ModifyCommand("-l 1 -rep 1.0E-1000").execute();
+        actualOutput = output.toString();
+        output.reset();
+        expectedOutput = getExpectedOutput(output, "Unable to parse String '1.0E-1000' into integer.");
+        assertEquals(expectedOutput, actualOutput);
+
+        new ModifyCommand("-l 1 -rep 0").execute();
+        actualOutput = output.toString();
+        output.reset();
+        expectedOutput = getExpectedOutput(output, "Provide a \"-rep\" number from 1 to 7");
+        assertEquals(expectedOutput, actualOutput);
+
+        new ModifyCommand("-l 1 -rep 8").execute();
+        actualOutput = output.toString();
+        output.reset();
+        expectedOutput = getExpectedOutput(output, "Provide a \"-rep\" number from 1 to 7");
         assertEquals(expectedOutput, actualOutput);
 
         System.setOut(originalOut); // restore stream


### PR DESCRIPTION
# Checklist for non-implementation related PR
Fixes #244, fixes #245
- [x] Added relevant milestone (under milestone tab on the right)
- Documentation (Contributions)
  - [ ] Developer Guide contributions (if any)
  - [ ] User Guide contributions (if any)
  - [ ] Review contributions (if any)
  - [ ] Miscellaneous and team-based admin tasks (if any)


# Additional Information
- Initial thoughts of bug for aborted modify, where by name has not been modified but rollback tries to revert the name and will cause an issue. After investigation, it was found to be a non-issue as name is, possibly, always evaluated first. In place of this uncertainty, a safety mechanism has been put in place whereby a list of `ArgumentName` is stored to keep track of whether name has been modified, in order to know whether to revert the `DailyMedication` name when rolling back changes.
